### PR TITLE
Feat: repeat last motion

### DIFF
--- a/lua/flit.lua
+++ b/lua/flit.lua
@@ -260,7 +260,7 @@ local function setup (args)
   local labeled_modes =
     args.labeled_modes and args.labeled_modes:gsub('v', 'x') or 'x'
 
-  keys = args.keys or args.keymaps or { f = 'f', F = 'F', t = 't', T = 'T' }
+  local keys = args.keys or args.keymaps or { f = 'f', F = 'F', t = 't', T = 'T' }
 
   local key_specific_leap_args = {
     [keys.f] = {},

--- a/lua/flit.lua
+++ b/lua/flit.lua
@@ -57,10 +57,12 @@ local function get_targets_callback (backward, use_no_labels, multiline, repeat_
     if ch then return handle_repeat(ch) end
   end
 
+  -- Construct search pattern from input
   local get_pattern = function (input)
     -- See `expand-to-equivalence-class` in `leap`.
     -- Gotcha! 'leap'.opts redirects to 'leap.opts'.default - we want .current_call!
     local chars = require('leap.opts').eq_class_of[input]
+    -- Sanitize input and produce pattern out of each char
     if chars then
       chars = vim.tbl_map(
         function (ch)
@@ -73,6 +75,9 @@ local function get_targets_callback (backward, use_no_labels, multiline, repeat_
       )
       input = '\\(' .. table.concat(chars, '\\|') .. '\\)'  -- '\(a\|b\|c\)'
     end
+    -- Construct final search query
+    -- \V – disable any magic character(all magic happens explicitly)
+    -- \\%.l – search only on current line
     return '\\V' .. (multiline == false and '\\%.l' or '') .. input
   end
 


### PR DESCRIPTION
Hello, this PR adds support for repeating `fFtT` with `;,`. Changes are mostly related to remembering last manually performed motion(ie. motion triggered by `fFtT`) and correct handling of all combinations of going forward/backward and repeating forward/backward with and without offset. Dot-repetition and `;,`-repetition are tied together

There are some limitations though:
- dot-repeating dT does not work (same behavior as before PR)
- pressing ;,, or ,;; goes to last/first target on screen(shown on video)

https://github.com/user-attachments/assets/2390bb48-19b9-4769-914a-db697264a7b2

Thank you for leap and flit, hope to see spooky.nvim shine some day.